### PR TITLE
require bear/framework

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,30 +11,7 @@
         }
     ],
     "require":{
-        "php":">=5.4.0",
-        "ext-curl":"*",
-        "bear/resource":"0.9.*",
-        "ray/di":"1.1.*",
-        "ray/aop":"1.1.*",
-        "bear/sunday":"0.9.*",
-        "bear/ace":"1.0.*",
-        "aura/input": "1.1.*",
-        "aura/view": "1.1.2",
-        "doctrine/annotations":"1.*",
-        "doctrine/cache":"1.*",
-        "doctrine/dbal":"2.3.*",
-        "guzzle/guzzle":"3.3.*",
-        "nocarrier/hal":"0.9.*",
-        "pagerfanta/pagerfanta":"1.*",
-        "smarty/smarty":"3.1.*",
-        "symfony/console":"2.0.*",
-        "symfony/http-foundation":"2.0.*",
-        "symfony/routing": "2.2.*",
-        "twitter/bootstrap":"2.*",
-        "zendframework/zend-log":"2.1.*",
-        "zendframework/zend-db": "2.1.*",
-        "zendframework/zend-stdlib": "2.1.*",
-        "classpreloader/classpreloader": "1.*"
+        "bear/framework":"*"
     },
     "require-dev":{
         "printo/printo":"0.1.*",

--- a/composer.lock
+++ b/composer.lock
@@ -3,7 +3,7 @@
         "This file locks the dependencies of your project to a known state",
         "Read more about it at http://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file"
     ],
-    "hash": "bc70ec71241daed049ae10e7c40b6c0b",
+    "hash": "d25af4a60fa47a0158caa533227cf349",
     "packages": [
         {
             "name": "any/serializer",
@@ -210,6 +210,59 @@
                 "installer"
             ],
             "time": "2012-11-26 21:35:57"
+        },
+        {
+            "name": "aura/router",
+            "version": "1.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/auraphp/Aura.Router.git",
+                "reference": "3a2a45fbb621729d572427b2a7b1d5859bc07789"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/auraphp/Aura.Router/zipball/3a2a45fbb621729d572427b2a7b1d5859bc07789",
+                "reference": "3a2a45fbb621729d572427b2a7b1d5859bc07789",
+                "shasum": ""
+            },
+            "require": {
+                "aura/installer-default": ">=1.0.0",
+                "php": ">=5.4.0"
+            },
+            "type": "aura-package",
+            "autoload": {
+                "psr-0": {
+                    "Aura\\Router": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD"
+            ],
+            "authors": [
+                {
+                    "name": "Paul M. Jones",
+                    "email": "pmjones88@gmail.com",
+                    "homepage": "http://paul-m-jones.com"
+                },
+                {
+                    "name": "Hari KT",
+                    "email": "kthari85@gmail.com",
+                    "homepage": "http://harikt.com"
+                },
+                {
+                    "name": "Aura.Router Contributors",
+                    "homepage": "https://github.com/auraphp/Aura.Router/contributors"
+                }
+            ],
+            "description": "The Aura Router package implements web routing; given a URI path and a copy of $_SERVER, it will extract controller, action, and parameter values for a specific route.",
+            "homepage": "http://auraphp.github.com/Aura.Router",
+            "keywords": [
+                "route",
+                "router",
+                "routing"
+            ],
+            "time": "2012-11-28 00:00:00"
         },
         {
             "name": "aura/signal",
@@ -430,6 +483,89 @@
                 "online editor"
             ],
             "time": "2013-06-21 04:38:46"
+        },
+        {
+            "name": "bear/package",
+            "version": "0.9.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/koriym/BEAR.Package.git",
+                "reference": "f7909f9dd1e6a18337d6415f60e5d91410a01a1c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/koriym/BEAR.Package/zipball/f7909f9dd1e6a18337d6415f60e5d91410a01a1c",
+                "reference": "f7909f9dd1e6a18337d6415f60e5d91410a01a1c",
+                "shasum": ""
+            },
+            "require": {
+                "aura/input": "1.1.*",
+                "aura/router": "1.0.*",
+                "aura/view": "1.1.2",
+                "bear/ace": "1.0.*",
+                "bear/resource": "0.9.*",
+                "bear/sunday": "0.9.*",
+                "classpreloader/classpreloader": "1.*",
+                "doctrine/annotations": "1.*",
+                "doctrine/cache": "1.*",
+                "doctrine/dbal": "2.3.*",
+                "ext-curl": "*",
+                "guzzle/guzzle": "3.3.*",
+                "nocarrier/hal": "0.9.*",
+                "pagerfanta/pagerfanta": "1.*",
+                "php": ">=5.4.0",
+                "ray/aop": "1.1.*",
+                "ray/di": "1.1.*",
+                "smarty/smarty": "3.1.*",
+                "symfony/console": "2.0.*",
+                "symfony/http-foundation": "2.0.*",
+                "symfony/routing": "2.2.*",
+                "twitter/bootstrap": "2.*",
+                "zendframework/zend-db": "2.1.*",
+                "zendframework/zend-log": "2.1.*",
+                "zendframework/zend-stdlib": "2.1.*"
+            },
+            "provide": {
+                "bear/framework": "0.8.0"
+            },
+            "require-dev": {
+                "dg/adminer-custom": "1.*",
+                "facebook/xhprof": "dev-master",
+                "firephp/firephp-core": "*",
+                "printo/printo": "0.1.*",
+                "twig/twig": "1.*"
+            },
+            "suggest": {
+                "bear/phptal-module": "PHPTAL template-engine module"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-0": {
+                    "BEAR\\Package": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "BEAR.Package Contributors",
+                    "homepage": "https://github.com/koriym/BEAR.Package/graphs/contributors"
+                }
+            ],
+            "description": "BEAR.Sunday framework package",
+            "homepage": "https://github.com/koriym/BEAR.Package",
+            "keywords": [
+                "BEAR.Sunday",
+                "aop",
+                "api",
+                "di",
+                "framework",
+                "hypermedia",
+                "rest"
+            ],
+            "time": "2013-10-12 17:51:35"
         },
         {
             "name": "bear/resource",
@@ -2099,10 +2235,9 @@
     "stability-flags": {
         "facebook/xhprof": 20
     },
-    "platform": {
-        "php": ">=5.4.0",
-        "ext-curl": "*"
-    },
+    "platform": [
+
+    ],
     "platform-dev": [
 
     ]


### PR DESCRIPTION
require `bear/framework` is simpler way to have application centric BEAR.Package installation.
BEAR.Package framework files are placed under `vendor/` directory as vendor/bear/package/*
